### PR TITLE
Added addressing modes of 6502 ISA

### DIFF
--- a/src/include/cpu.h
+++ b/src/include/cpu.h
@@ -1,1 +1,20 @@
-struct Cpu {};
+#include <cstdint>
+
+// clang-format off
+/** All addressing modes supported by the ISA*/
+enum AddressingModesKind : uint8_t {
+  Implicit,        // [opcode 1B]
+  Accumulator,     // [opcode 1B]              -> accumulator source and destination
+  Immediate,       // [opcode 1B] [operand 2B] -> 16-bit address = operand
+  ZeroPage,        // [opcode 1B] [operand 1B] -> operand is an 8-bit address in the ZeroPage Range
+  ZeroPageX,       // [opcode 1B] [operand 1B] -> 8-bit address = operand + X
+  ZeroPageY,       // [opcode 1B] [operand 1B] -> 8-bit address = operand + Y
+  Relative,        // [opcode 1B] [operand 1B] -> Signed 8-bit address -> PC + operand
+  Absolute,        // [opcode 1B] [operand 2B] -> 16-bit operand (LSB first)
+  AbsoluteX,       // [opcode 1B] [operand 2B] -> 16-bit operand (LSB first) + X
+  AbsoluteY,       // [opcode 1B] [operand 2B] -> 16-bit operand (LSB first) + Y
+  Indirect,        // [opcode 1B] [operand 2B] -> 16-bit address = memory[operand+1] (msb) | memory[operand] (lsb) 
+  IndexedIndirect, // [opcode 1B] [operand 2B] -> 16-bit address = memory[operand+X+1] (msb) | memory[operand+X] (lsb)  
+  IndirectIndexed  // [opcode 1B] [operand 2B] -> 16-bit address =  (memory[operand+1] (msb) | memory[operand] (lsb)) + Y
+};
+// clang-format on


### PR DESCRIPTION
The 6502 ISA has 13 different addressing mode, this enum defines each of them.